### PR TITLE
perf: fix scroll lag — remove animated blur, static backgrounds

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -90,43 +90,16 @@ section {
 }
 
 /* ============================================
-   Animated Background
+   Static Background (no animation — zero scroll cost)
    ============================================ */
 .bg-orbs {
   position: fixed;
   inset: 0;
   z-index: 0;
-  overflow: hidden;
   pointer-events: none;
-  transform: translateZ(0);
-  will-change: transform;
-}
-
-.bg-orbs::before,
-.bg-orbs::after {
-  content: '';
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(60px);
-  animation: orbFloat 20s ease-in-out infinite;
-  will-change: transform;
-}
-
-.bg-orbs::before {
-  width: 600px;
-  height: 600px;
-  background: var(--accent-glow);
-  top: -200px;
-  left: -100px;
-}
-
-.bg-orbs::after {
-  width: 500px;
-  height: 500px;
-  background: var(--indigo-glow);
-  bottom: -150px;
-  right: -100px;
-  animation-delay: -10s;
+  background:
+    radial-gradient(ellipse 600px 600px at 20% -10%, var(--accent-glow) 0%, transparent 70%),
+    radial-gradient(ellipse 500px 500px at 80% 110%, var(--indigo-glow) 0%, transparent 70%);
 }
 
 .bg-grid {
@@ -134,20 +107,11 @@ section {
   inset: 0;
   z-index: 0;
   pointer-events: none;
+  opacity: 0.4;
   background-image:
-    linear-gradient(rgba(255, 255, 255, 0.018) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
+    linear-gradient(rgba(255,255,255,0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.025) 1px, transparent 1px);
   background-size: 64px 64px;
-  mask-image: radial-gradient(ellipse 60% 60% at 50% 40%, black 20%, transparent 70%);
-  -webkit-mask-image: radial-gradient(ellipse 60% 60% at 50% 40%, black 20%, transparent 70%);
-}
-
-/* Noise layer removed for scroll performance */
-
-@keyframes orbFloat {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  33% { transform: translate(60px, -40px) scale(1.08); }
-  66% { transform: translate(-30px, 30px) scale(0.94); }
 }
 
 /* ============================================
@@ -376,7 +340,7 @@ section {
   text-align: left;
   animation: fadeInUp 0.6s ease 0.2s both;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-  min-height: 110px;
+  min-height: 140px;
 }
 
 .terminal-header {
@@ -985,7 +949,7 @@ section {
   .terminal-box {
     margin-left: 0;
     margin-right: 0;
-    min-height: 100px;
+    min-height: 120px;
   }
 
   .terminal-body {

--- a/index.html
+++ b/index.html
@@ -271,7 +271,6 @@
   <script src="assets/js/bootstrap.min.js"></script>
   <script src="assets/js/jasny-bootstrap.min.js"></script>
   <script src="assets/js/wow.js"></script>
-  <script src="assets/js/smooth-scroll.js"></script>
   <script src="assets/js/main.js"></script>
   <script>
     document.getElementById('current-year').textContent = new Date().getFullYear();


### PR DESCRIPTION
## Root Cause

The `blur(60px)` CSS filter ran inside a 20-second `@keyframes` animation on elements up to 600px wide. The browser re-blurred on **every single frame**, which is the most expensive CSS operation possible. Combined with `mask-image` compositing and an unused scroll listener, scrolling was laggy.

## Fixes

| Before | After |
|--------|-------|
| `filter: blur(60px)` + 20s `@keyframes orbFloat` animation | Static `radial-gradient()` — zero per-frame cost |
| `mask-image: radial-gradient(...)` on bg-grid | Removed, simple repeating grid only |
| `smooth-scroll.js` (external scroll listener) | Removed — CSS `scroll-behavior: smooth` handles it |
| Terminal min-height 110px | 140px — no more layout shift on text wrap |

Background still looks the same visually — two colored gradient blotches top-left and bottom-right — but rendered once as a static image with no animation overhead.
