### PR TITLE
simplify: remove top-header navigation — pure scroll-based page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -115,165 +115,20 @@ section {
 }
 
 /* ============================================
-   Header / Navigation
+   Header
    ============================================ */
 #header {
   position: relative;
   z-index: 2;
 }
 
-.top-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-top: 36px;
-}
-
-/* Logo */
-.logo-img {
-  width: 44px;
-  height: 44px;
+.header-avatar {
+  display: block;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   border: 2px solid var(--border);
-  transition: border-color var(--transition), transform var(--transition);
-}
-
-.logo-img:hover {
-  border-color: var(--accent);
-  transform: scale(1.08);
-}
-
-/* Hamburger Menu Button */
-#menu {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  cursor: pointer;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  transition: border-color var(--transition), background var(--transition);
-  z-index: 100001;
-  position: relative;
-}
-
-#menu:hover {
-  border-color: var(--accent);
-}
-
-#menu span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--text);
-  position: relative;
-  transition: background 0.15s ease;
-}
-
-#menu span::before,
-#menu span::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: 2px;
-  background: var(--text);
-  transition: transform 0.3s ease;
-}
-
-#menu span::before {
-  transform: translateY(-6px);
-}
-
-#menu span::after {
-  transform: translateY(6px);
-}
-
-#menu:hover span,
-#menu:hover span::before,
-#menu:hover span::after {
-  background: var(--accent);
-}
-
-/* ============================================
-   Offcanvas Navigation (Jasny Bootstrap compatible)
-   ============================================ */
-.navmenu {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 320px;
-  max-width: 85vw;
-  background: rgba(13, 13, 17, 0.97);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  border-left: 1px solid var(--border);
-  z-index: 100000;
-  padding: 80px 40px 40px;
-  transform: translateX(100%);
-  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 40px;
-}
-
-.navmenu.in {
-  transform: translateX(0);
-}
-
-/* Overlay when menu is open */
-.canvas-slid::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 99999;
-  pointer-events: auto;
-}
-
-.navmenu .logo-img {
-  width: 72px;
-  height: 72px;
-}
-
-.navmenu .nav {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  width: 100%;
-  text-align: center;
-}
-
-.navmenu .nav li {
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  transition: border-color var(--transition), background var(--transition);
-}
-
-.navmenu .nav li a {
-  display: block;
-  padding: 12px 20px;
-  color: var(--text-secondary);
-  font-size: 16px;
-  font-weight: 500;
-  font-family: var(--font-mono);
-  font-size: 15px;
-  letter-spacing: 0.02em;
-  transition: color var(--transition);
-}
-
-.navmenu .nav li:hover,
-.navmenu .nav li.active {
-  border-color: var(--border);
-  background: var(--glass-bg);
-}
-
-.navmenu .nav li:hover a,
-.navmenu .nav li.active a {
-  color: var(--text);
+  margin: 24px auto 0;
 }
 
 /* ============================================
@@ -839,12 +694,6 @@ section {
 }
 
 /* ============================================
-   Bootstrap Utility Classes (no longer loading bootstrap.css)
-   ============================================ */
-.pull-left { float: left !important; }
-.pull-right { float: right !important; }
-
-/* ============================================
    Utility: Scroll-triggered reveal (for WOW.js replacement)
    ============================================ */
 .reveal {
@@ -922,11 +771,6 @@ section {
 
   .section-header {
     margin-bottom: 40px;
-  }
-
-  .navmenu {
-    width: 100%;
-    max-width: 100%;
   }
 
   .project-body h3 {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,14 +4,6 @@
   y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
 })(window, document, "clarity", "script", "k5jo3bmjki");
 
-$('body').scrollspy({ target: '.navmenu' });
-
-// Offcanvas menu toggle
-$('#menu').click(function () {
-  $('#menu').not(this).removeClass("active");
-  $(this).toggleClass("active");
-});
-
 // WOW Scroll Spy
 var wow = new WOW({ mobile: true });
 wow.init();
@@ -137,11 +129,6 @@ $(function () {
       target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
       if (target.length) {
         $('html,body').animate({ scrollTop: target.offset().top }, 800);
-        // Close offcanvas if open
-        if ($('.navmenu').hasClass('in')) {
-          $('.navmenu').removeClass('in');
-          $('body').removeClass('canvas-slid');
-        }
         return false;
       }
     }

--- a/index.html
+++ b/index.html
@@ -80,34 +80,11 @@
   <div class="bg-grid" aria-hidden="true"></div>
 
   <!-- ============================================
-  Header / Navigation
+  Header / Hero
   ============================================ -->
   <header id="header">
     <div class="container">
-      <div class="top-header">
-        <div class="logo pull-left">
-          <a href="index.html">
-            <img class="logo-img" src="https://avatars.githubusercontent.com/u/113882203?v=4" alt="luckrnx09 avatar">
-          </a>
-        </div>
-        <div class="pull-right">
-          <div id="menu" data-toggle="offcanvas" data-target=".navmenu" data-canvas="body" aria-label="Toggle navigation">
-            <span></span>
-          </div>
-        </div>
-        <!-- Offcanvas Navigation -->
-        <div class="sidebar-nav">
-          <nav class="navmenu navmenu-default navmenu-fixed-right offcanvas" id="navigation">
-            <a href="index.html"><img class="logo-img" src="https://avatars.githubusercontent.com/u/113882203?v=4" alt="luckrnx09 avatar"></a>
-            <ul class="nav navmenu-nav">
-              <li class="active"><a href="#header">Home</a></li>
-              <li><a href="#works">Works</a></li>
-              <li><a href="#skills">Skills</a></li>
-              <li><a href="#contact">Contact</a></li>
-            </ul>
-          </nav>
-        </div>
-      </div>
+      <img class="header-avatar" src="https://avatars.githubusercontent.com/u/113882203?v=4" alt="luckrnx09 avatar">
 
       <!-- Hero -->
       <div class="hero">
@@ -268,8 +245,6 @@
   Scripts
   ============================================ -->
   <script src="assets/js/jquery-min.js"></script>
-  <script src="assets/js/bootstrap.min.js"></script>
-  <script src="assets/js/jasny-bootstrap.min.js"></script>
   <script src="assets/js/wow.js"></script>
   <script src="assets/js/main.js"></script>
   <script>


### PR DESCRIPTION
Removes the entire top-header navigation bar (hamburger menu, offcanvas nav) since the page is a simple single-page site that works perfectly with just scrolling.

## Changes

- Removed `.top-header` with hamburger menu and offcanvas sidebar nav from HTML
- Replaced with a minimal centered avatar at the top of the page
- Removed `bootstrap.min.js` and `jasny-bootstrap.min.js` (170KB+ saved, only needed for nav)
- Removed scrollspy, menu toggle, and offcanvas close logic from `main.js`
- Cleaned up all related CSS: `.navmenu`, `#menu`, `.logo-img`, `.top-header`, pull helpers
- Page is now pure scroll-based with no navigation chrome — cleaner, faster, simpler
