### PR TITLE
update: use actual CursorX README screenshot for project card

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,19 +138,7 @@
           <!-- CursorX Project -->
           <article class="project-card">
             <div class="project-visual">
-              <div class="project-placeholder">
-                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-                  <defs>
-                    <linearGradient id="cursorx-grad" x1="0" y1="0" x2="1" y2="1">
-                      <stop offset="0%" stop-color="#818cf8"/>
-                      <stop offset="100%" stop-color="#22d3ee"/>
-                    </linearGradient>
-                  </defs>
-                  <path d="M20 20 L55 65 L45 68 L55 80 L42 82 L34 68 L22 75 Z" fill="url(#cursorx-grad)" opacity="0.8"/>
-                  <circle cx="52" cy="36" r="20" fill="none" stroke="url(#cursorx-grad)" stroke-width="2.5" opacity="0.5"/>
-                  <circle cx="52" cy="36" r="6" fill="url(#cursorx-grad)" opacity="0.6"/>
-                </svg>
-              </div>
+              <img src="https://raw.githubusercontent.com/luckrnx09/CursorX/main/screenshots/CursorX.png" alt="CursorX screenshot — cursor highlighting desktop app">
             </div>
             <div class="project-body">
               <h3>CursorX</h3>


### PR DESCRIPTION
Replaces the placeholder SVG icon in the CursorX project card with the actual screenshot from the CursorX README.

Image: `https://raw.githubusercontent.com/luckrnx09/CursorX/main/screenshots/CursorX.png`
